### PR TITLE
Fix incompatible type in RepsCollection and composer.json being outdated.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
     "require-dev": {
         "phpunit/phpunit": "^8.4",
         "aws/aws-sdk-php": "^3.0@dev",
-        "google/cloud-storage": "dev-master",
+        "google/cloud-storage": "dev-main",
         "microsoft/azure-storage-blob": "dev-master"
     },
     "autoload-dev": {

--- a/src/RepsCollection.php
+++ b/src/RepsCollection.php
@@ -98,7 +98,7 @@ class RepsCollection implements \Countable, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->representations);
     }


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #127 
| License            | MIT

#### What's in this PR?
This PR fixes issue #127, which had the library crash on use because of incompatible types being returned by the `RepsCollection` classes `getIterator()` function.

It also fixes an issue where `composer install` will fail to install this project's dependencies because `"google/cloud-storage": "dev-master" was renamed to "google/cloud-storage": "dev-main"`

#### Why?

See above