### PR TITLE
Handle streams that are rotated 90° or 270°

### DIFF
--- a/src/AutoReps.php
+++ b/src/AutoReps.php
@@ -74,7 +74,13 @@ class AutoReps implements \IteratorAggregate
     private function getDimensions(): Dimension
     {
         try {
-            return $this->video->getDimensions();
+            $rotation = (int) ($this->video->get('tags')['rotate'] ?? 0);
+            $dimensions = $this->video->getDimensions();
+
+            return ($rotation % 180 == 0)
+                ? $dimensions
+                : new Dimension($dimensions->getHeight(), $dimensions->getWidth());
+
         } catch (ExceptionInterface $e) {
             throw new RuntimeException("Unable to extract dimensions.: " . $e->getMessage(), $e->getCode(), $e);
         }


### PR DESCRIPTION

| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #83
| License            | MIT

#### What's in this PR?

Change `getDimensions()` in `AutoReps` to check stream rotation and return effective dimensions, by flipping height/width when rotation is 90° or 270°.

#### Which problem does the PR fix?

Portrait videos from e.g. iPhones are mistakenly assumed to have landscape orientation, because `displaymatrix: rotation of -90.00 degrees` is not taken into account in `AutoReps`.

