### PR TITLE
Also filter bitrates

### DIFF
--- a/src/AutoReps.php
+++ b/src/AutoReps.php
@@ -99,7 +99,6 @@ class AutoReps implements \IteratorAggregate
 
     /**
      * @param array|null $k_bitrate_values
-     * @TODO: fix #79
      */
     private function kiloBitrate(?array $k_bitrate_values): void
     {
@@ -139,13 +138,29 @@ class AutoReps implements \IteratorAggregate
      * @param array|null $sides
      * @param array|null $k_bitrate
      */
-    private function sides(?array $sides, ?array $k_bitrate): void
+    private function sides(?array $sides, ?array &$k_bitrate): void
     {
-        if (!is_null($sides) && is_null($k_bitrate)) {
+        if (! is_null($sides) && is_null($k_bitrate)) {
             sort($sides);
         }
 
-        $this->sides = array_values(array_filter($sides ?? $this->sides, [$this, 'sideFilter']));
+        $filtered = [];
+
+        foreach ($sides ?? $this->sides as $i => $side) {
+            if ($this->sideFilter($side)) {
+                $filtered[] = $side;
+            } elseif ($k_bitrate !== null) {
+                // Remove bitrate for filtered side
+                unset($k_bitrate[$i]);
+            }
+        }
+
+        $this->sides = $filtered;
+
+        if ($k_bitrate !== null) {
+            // Reindex
+            $k_bitrate = array_values($k_bitrate);
+        }
     }
 
     /**

--- a/tests/HLSTest.php
+++ b/tests/HLSTest.php
@@ -51,6 +51,22 @@ class HLSTest extends TestCase
         $this->assertEquals(207, $representations[2]->getKiloBitrate());
     }
 
+    public function testAutoRepresentationsWithBitrates()
+    {
+        $hls = $this->getHLS();
+        $hls->X264()
+            ->autoGenerateRepresentations([640, 480, 240], [500, 300, 150]);
+
+        $representations = $hls->getRepresentations()->all();
+
+        $this->assertIsArray($representations);
+        $this->assertInstanceOf(Representation::class, current($representations));
+
+        $this->assertEquals('426x240', $representations[0]->size2string());
+
+        $this->assertEquals(150, $representations[0]->getKiloBitrate());
+    }
+
     public function testSetHlsTime()
     {
         $hls = $this->getHLS();


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | yes
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | fixes #79
| License            | MIT

#### What's in this PR?

This changes the filtering in `AutoReps->sides()` to also remove corresponding bitrates, in case a size is rejected.

#### Why?

This fixes the issue where `autoGenerateRepresentations()` would fail with `The count of side value array must be the same as the count of kilo bitrate array` in cases where both sizes and bitrates are provided, and filtering rejects some of the sizes.

